### PR TITLE
Feature - Implemented moving sub kanji from kanji resource deck to new kanji deck

### DIFF
--- a/AnkiJapaneseFlashcardManagerTest/Anki2ControllerTests.cs
+++ b/AnkiJapaneseFlashcardManagerTest/Anki2ControllerTests.cs
@@ -515,5 +515,37 @@ namespace AnkiJapaneseFlashcardManagerTest
 			changedCards.Select(p => p.UpdatedCard.DeckId).Should().AllBeEquivalentTo(expectedToDeckId);//Updated deck id should match
 			changedCards.Select(p => p.UpdatedCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Updated notes should match
 		}
+
+		[Theory]
+		[InlineData("飲newKanji_食欠人良resourceKanji_decks.anki2", new[] { 1707169497960, 1707169570657, 1707169983389, 1707170000793 }, 1707160947123, 1707160682667)]
+		public void Move_resource_sub_kanji_notes_to_new_kanji_deck(string anki2File, long[] expectedNoteIdsToMove, long expectedFromDeckId, long expectedToDeckId)
+		{
+			//Arrange
+			string originalInputFilePath = _anki2FolderPath + anki2File;
+			string tempInputFilePath = _anki2FolderPath + "temp_" + anki2File;
+			File.Copy(originalInputFilePath, tempInputFilePath, true);//Copy the input file to prevent changes between unit tests
+			Anki2Controller anki2Controller = new Anki2Controller(tempInputFilePath);
+			List<Card> allOriginalCards = anki2Controller.GetTable<Card>();
+
+			//Act
+			bool movedNotes = anki2Controller.MoveResourceSubKanjiToNewKanji();
+
+			//Get Assert Values
+			//Get changed cards
+			var allCardsAfterFunction = anki2Controller.GetTable<Card>();
+			var changedCards = allOriginalCards
+				.Join(allCardsAfterFunction,
+					originalCard => originalCard.Id,
+					updatedCard => updatedCard.Id,
+					(originalCard, updatedCard) => new { OriginalCard = originalCard, UpdatedCard = updatedCard })
+				.Where(pair => !pair.OriginalCard.Equals(pair.UpdatedCard))
+				.ToList();
+			//Assert
+			movedNotes.Should().BeTrue();//Function completed successfully
+			changedCards.Select(p => p.OriginalCard.DeckId).Should().AllBeEquivalentTo(expectedFromDeckId);//Original deck id should match
+			changedCards.Select(p => p.OriginalCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Original notes should match
+			changedCards.Select(p => p.UpdatedCard.DeckId).Should().AllBeEquivalentTo(expectedToDeckId);//Updated deck id should match
+			changedCards.Select(p => p.UpdatedCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Updated notes should match
+		}
 	}
 }

--- a/AnkiSentenceCardBuilder/Controllers/Anki2Controller.cs
+++ b/AnkiSentenceCardBuilder/Controllers/Anki2Controller.cs
@@ -230,9 +230,28 @@ namespace AnkiSentenceCardBuilder.Controllers
 			return MoveNotesBetweenDecks(newKanjiNoteIdsToMove, learningKanjiDeckId);
 		}
 
-		public bool MoveResourceSubKanjiToNewKanji()//TODO
+		public bool MoveResourceSubKanjiToNewKanji()
 		{
-			return false;
+			//Get the kanji resource decks
+			var kanjiResourceDecks = GetResourceKanjiDecks();
+			//Get the kanji resource notes
+			var kanjiResourceNotes = kanjiResourceDecks.SelectMany(d => GetDeckNotes(d.Id)).ToList();
+			//Get the new kanji decks
+			var newKanjiDecks = GetNewKanjiDecks();
+			//Fail if no new kanji decks found
+			if (!newKanjiDecks.Any()) { return false; }
+			//Get the new kanji notes
+			var newKanjiNotes = newKanjiDecks.SelectMany(d => GetDeckNotes(d.Id)).ToList();
+			//Pull kanji resource notes based on the new kanji sub kanji ids
+			var SubKanjiResourceNotes = PullAllSubKanjiNotesFromNoteList(ref kanjiResourceNotes, newKanjiNotes);
+			//Skip if no new kanji sub kanji notes to move
+			if (!SubKanjiResourceNotes.Any()) { return true; }
+			//Get the sub kanji resource note ids
+			var subKanjiResourceNoteIdsToMove = SubKanjiResourceNotes.Select(n => n.Id).ToList();
+			//Get the first new kanji deck id to move the resource kanji notes to
+			var newKanjiDeckId = newKanjiDecks.First().Id;
+			//Move the resource kanji notes to the new kanji deck
+			return MoveNotesBetweenDecks(subKanjiResourceNoteIdsToMove, newKanjiDeckId);
 		}
 	}
 }

--- a/AnkiSentenceCardBuilder/Controllers/Anki2Controller.cs
+++ b/AnkiSentenceCardBuilder/Controllers/Anki2Controller.cs
@@ -229,5 +229,10 @@ namespace AnkiSentenceCardBuilder.Controllers
 			//Move the new kanji notes to the learning kanji deck
 			return MoveNotesBetweenDecks(newKanjiNoteIdsToMove, learningKanjiDeckId);
 		}
+
+		public bool MoveResourceSubKanjiToNewKanji()//TODO
+		{
+			return false;
+		}
 	}
 }

--- a/AnkiSentenceCardBuilder/Services/LocalTestingFunction.cs
+++ b/AnkiSentenceCardBuilder/Services/LocalTestingFunction.cs
@@ -53,6 +53,11 @@ namespace AnkiSentenceCardBuilder.Services
 			//Update the DB to move the pulled notes from the resource kanji decks to the new kanji decks
 			bool movedFromResourceToNewKanji = anki2Controller.MoveNotesBetweenDecks(newKanjiSubKanjiNotes.Select(n => n.Id), newKanjiDecks.Select(d => d.Id).First());
 
+			//Update to pull sub kanji notes from the kanji resource decks into the new kanji deck based on the existing new kanji notes
+
+			//Update to pull valid new kanji notes into the learning kanji deck
+			bool movedFromNewKanjiToLearningKanjiDeck = anki2Controller.MoveNewKanjiToLearningKanji();
+
 			anki2Controller.Dispose();
 
 			//Exit

--- a/AnkiSentenceCardBuilder/Services/LocalTestingFunction.cs
+++ b/AnkiSentenceCardBuilder/Services/LocalTestingFunction.cs
@@ -36,14 +36,14 @@ namespace AnkiSentenceCardBuilder.Services
 			//List<Deck> decks = anki2Controller.GetTable<Deck>();
 
 			//Find the decks with the kanji resource binding
-			List<Deck> resourceKanjiDecks = anki2Controller.GetResourceKanjiDecks();
+				List<Deck> resourceKanjiDecks = anki2Controller.GetResourceKanjiDecks();
 			//Find the decks with the new kanji binding
 			List<Deck> newKanjiDecks = anki2Controller.GetNewKanjiDecks();
 			//Find the decks with the learning kanji binding
 			List<Deck> learningKanjiDecks = anki2Controller.GetLearningKanjiDecks();
 
 			//Get notes from the kanji resource decks
-			List<Note> resourceKanjiNotes = resourceKanjiDecks.SelectMany(d => anki2Controller.GetDeckNotes(d.Id)).ToList();
+				List<Note> resourceKanjiNotes = resourceKanjiDecks.SelectMany(d => anki2Controller.GetDeckNotes(d.Id)).ToList();
 			//Get notes from the new kanji decks
 			List<Note> newKanjiNotes = newKanjiDecks.SelectMany(d => anki2Controller.GetDeckNotes(d.Id)).ToList();
 


### PR DESCRIPTION
Implemented MoveResourceSubKanjiToNewKanji().

Unit test Move_resource_sub_kanji_notes_to_new_kanji_deck() passes by itself but fails when ran with all tests. The issue comes from the test Move_notes_between_decks() keeping the same test file open and preventing this test from refreshing the data.
Issue marked in:
https://github.com/TMason11095/anki-japanese-flashcard-manager/issues/6