### PR TITLE
Bug - Fixed temp SQLite files not being deleted in unit tests

### DIFF
--- a/AnkiJapaneseFlashcardManagerTest/Anki2ControllerTests.cs
+++ b/AnkiJapaneseFlashcardManagerTest/Anki2ControllerTests.cs
@@ -413,9 +413,9 @@ namespace AnkiJapaneseFlashcardManagerTest
 			finalNoteDeckJunctions.Count().Should().Be(originalNoteDeckJunctions.Count());//No note/deck relations should have been removed/added
 			finalNoteDeckJunctions.Select(c => c.DeckId).Should().AllBeEquivalentTo(deckIdToMoveTo);//All junction deckIds should be the given deckId
 
-			//Cleanup (Can't delete temp file since the file won't close until after the test ends)
-			//anki2Controller.Dispose();
-			//File.Delete(tempInputFilePath);
+			//Cleanup
+			anki2Controller.Dispose();
+			File.Delete(tempInputFilePath);
 		}
 
 		[Theory]
@@ -514,6 +514,10 @@ namespace AnkiJapaneseFlashcardManagerTest
 			changedCards.Select(p => p.OriginalCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Original notes should match
 			changedCards.Select(p => p.UpdatedCard.DeckId).Should().AllBeEquivalentTo(expectedToDeckId);//Updated deck id should match
 			changedCards.Select(p => p.UpdatedCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Updated notes should match
+
+			//Cleanup
+			anki2Controller.Dispose();
+			File.Delete(tempInputFilePath);
 		}
 
 		[Theory]
@@ -546,6 +550,10 @@ namespace AnkiJapaneseFlashcardManagerTest
 			changedCards.Select(p => p.OriginalCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Original notes should match
 			changedCards.Select(p => p.UpdatedCard.DeckId).Should().AllBeEquivalentTo(expectedToDeckId);//Updated deck id should match
 			changedCards.Select(p => p.UpdatedCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Updated notes should match
+
+			//Cleanup
+			anki2Controller.Dispose();
+			File.Delete(tempInputFilePath);
 		}
 	}
 }

--- a/AnkiSentenceCardBuilder/Controllers/Anki2Controller.cs
+++ b/AnkiSentenceCardBuilder/Controllers/Anki2Controller.cs
@@ -1,5 +1,6 @@
 ﻿using AnkiJapaneseFlashcardManager.Config;
 using AnkiSentenceCardBuilder.Models;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections;
@@ -12,7 +13,7 @@ namespace AnkiSentenceCardBuilder.Controllers
 {
     public class Anki2Controller : IDisposable
 	{
-        private readonly Anki2Context _context;
+        public readonly Anki2Context _context;
 
         public Anki2Controller(Anki2Context context)
         {
@@ -25,9 +26,9 @@ namespace AnkiSentenceCardBuilder.Controllers
 
 		public void Dispose()
 		{
+			SqliteConnection.ClearPool((SqliteConnection) _context.Database.GetDbConnection());
 			_context.Dispose();
 		}
-
 
 		public List<T> GetTable<T>() where T : class
         {


### PR DESCRIPTION
Implemented clearing the context's connection pool on Dispose() to fix the file not closing.

Readded code to call Dispose() and File.Delete() for tests:
- Move_notes_between_decks()
- Move_new_kanji_notes_to_learning_kanji_deck()
- Move_resource_sub_kanji_notes_to_new_kanji_deck().