### PR TITLE
Bug - Fixed unit test temp files from clashing with other tests

### DIFF
--- a/AnkiJapaneseFlashcardManagerTest/Anki2CardControllerTests.cs
+++ b/AnkiJapaneseFlashcardManagerTest/Anki2CardControllerTests.cs
@@ -68,7 +68,7 @@ namespace AnkiJapaneseFlashcardManagerTests
 		{
 			//Arrange
 			string originalInputFilePath = _anki2FolderPath + anki2File;
-			string tempInputFilePath = _anki2FolderPath + "temp_" + anki2File;
+			string tempInputFilePath = $"{_anki2FolderPath}temp_{Guid.NewGuid()}.anki2";
 			File.Copy(originalInputFilePath, tempInputFilePath, true);//Copy the input file to prevent changes between unit tests
 			Anki2Controller anki2Controller = new Anki2Controller(tempInputFilePath);
 			List<Card> originalNoteDeckJunctions = anki2Controller.GetTable<Card>()

--- a/AnkiJapaneseFlashcardManagerTest/ApplicationLayer/Services/Managements/KanjiServiceManagementTests.cs
+++ b/AnkiJapaneseFlashcardManagerTest/ApplicationLayer/Services/Managements/KanjiServiceManagementTests.cs
@@ -20,7 +20,7 @@ namespace AnkiJapaneseFlashcardManagerTests.ApplicationLayer.Services.Management
 		{
 			//Arrange
 			string originalInputFilePath = _anki2FolderPath + anki2File;
-			string tempInputFilePath = _anki2FolderPath + "temp_" + anki2File;
+			string tempInputFilePath = $"{_anki2FolderPath}temp_{Guid.NewGuid()}.anki2";
 			File.Copy(originalInputFilePath, tempInputFilePath, true);//Copy the input file to prevent changes between unit tests
 			Anki2Controller anki2Controller = new Anki2Controller(tempInputFilePath);
 			List<Card> allOriginalCards = anki2Controller.GetTable<Card>();
@@ -57,7 +57,7 @@ namespace AnkiJapaneseFlashcardManagerTests.ApplicationLayer.Services.Management
 		{
 			//Arrange
 			string originalInputFilePath = _anki2FolderPath + anki2File;
-			string tempInputFilePath = _anki2FolderPath + "temp_" + anki2File;
+			string tempInputFilePath = $"{_anki2FolderPath}temp_{Guid.NewGuid()}.anki2";
 			File.Copy(originalInputFilePath, tempInputFilePath, true);//Copy the input file to prevent changes between unit tests
 			Anki2Controller anki2Controller = new Anki2Controller(tempInputFilePath);
 			List<Card> allOriginalCards = anki2Controller.GetTable<Card>();

--- a/AnkiSentenceCardBuilder/DataAccessLayer/Contexts/Anki2Context.cs
+++ b/AnkiSentenceCardBuilder/DataAccessLayer/Contexts/Anki2Context.cs
@@ -28,6 +28,10 @@ namespace AnkiJapaneseFlashcardManager.DataAccessLayer.Contexts
         {
         }
 
+        public Anki2Context(DbContextOptions<Anki2Context> options) : base(options)
+        {
+        }
+
         private static DbContextOptions<Anki2Context> GetOptions(string dbPath)
         {
             return new DbContextOptionsBuilder<Anki2Context>()

--- a/AnkiSentenceCardBuilder/DataAccessLayer/Contexts/Anki2Context.cs
+++ b/AnkiSentenceCardBuilder/DataAccessLayer/Contexts/Anki2Context.cs
@@ -24,18 +24,16 @@ namespace AnkiJapaneseFlashcardManager.DataAccessLayer.Contexts
         //graves
         public DbSet<Note> Notes { get; protected set; }
 
-        private string _dbPath { get; }
-
-        public Anki2Context(string dbPath)
+        public Anki2Context(string dbPath) : base(GetOptions(dbPath))
         {
-            _dbPath = dbPath;
         }
 
-        //Override OnConfiguring to use Sqlite
-        protected override void OnConfiguring(DbContextOptionsBuilder options)
+        private static DbContextOptions<Anki2Context> GetOptions(string dbPath)
         {
-            options.UseSqlite($"Data Source={_dbPath}");
-        }
+            return new DbContextOptionsBuilder<Anki2Context>()
+				.UseSqlite($"Data Source={dbPath}")
+				.Options;
+		}
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
Updated unit tests temp file names from "temp_{originalFileName}" to "temp_{Guid}" to prevent random clashes of tests that create temp files of the same original file.