### PR TITLE
Refactor - Replaced Anki2Context.Dispose() with DbContextHelper.ClearSqlitePool()

### DIFF
--- a/AnkiJapaneseFlashcardManagerTest/Anki2CardControllerTests.cs
+++ b/AnkiJapaneseFlashcardManagerTest/Anki2CardControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using AnkiJapaneseFlashcardManager.DataAccessLayer.Contexts;
+using AnkiJapaneseFlashcardManager.DataAccessLayer.Helpers;
 using AnkiJapaneseFlashcardManager.DomainLayer.Entities;
 using AnkiSentenceCardBuilder.Controllers;
 using System;
@@ -91,7 +92,7 @@ namespace AnkiJapaneseFlashcardManagerTests
 			finalNoteDeckJunctions.Select(c => c.DeckId).Should().AllBeEquivalentTo(deckIdToMoveTo);//All junction deckIds should be the given deckId
 
 			//Cleanup
-			dbContext.Dispose();
+			DbContextHelper.ClearSqlitePool(dbContext);
 			File.Delete(tempInputFilePath);
 		}
 

--- a/AnkiJapaneseFlashcardManagerTest/ApplicationLayer/Services/Managements/KanjiServiceManagementTests.cs
+++ b/AnkiJapaneseFlashcardManagerTest/ApplicationLayer/Services/Managements/KanjiServiceManagementTests.cs
@@ -1,6 +1,7 @@
 ﻿using AnkiJapaneseFlashcardManager.ApplicationLayer.Services;
 using AnkiJapaneseFlashcardManager.ApplicationLayer.Services.Managements;
 using AnkiJapaneseFlashcardManager.DataAccessLayer.Contexts;
+using AnkiJapaneseFlashcardManager.DataAccessLayer.Helpers;
 using AnkiJapaneseFlashcardManager.DataAccessLayer.Interfaces.Contexts;
 using AnkiJapaneseFlashcardManager.DataAccessLayer.Repositories;
 using AnkiJapaneseFlashcardManager.DomainLayer.Entities;
@@ -53,7 +54,7 @@ namespace AnkiJapaneseFlashcardManagerTests.ApplicationLayer.Services.Management
 			changedCards.Select(p => p.UpdatedCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Updated notes should match
 
 			//Cleanup
-			anki2Context.Dispose();
+			DbContextHelper.ClearSqlitePool(anki2Context);
 			File.Delete(tempInputFilePath);
 		}
 
@@ -92,7 +93,7 @@ namespace AnkiJapaneseFlashcardManagerTests.ApplicationLayer.Services.Management
 			changedCards.Select(p => p.UpdatedCard.NoteId).Distinct().Should().BeEquivalentTo(expectedNoteIdsToMove);//Updated notes should match
 
 			//Cleanup
-			anki2Context.Dispose();
+			DbContextHelper.ClearSqlitePool(anki2Context);
 			File.Delete(tempInputFilePath);
 		}
 	}

--- a/AnkiSentenceCardBuilder/DataAccessLayer/Contexts/Anki2Context.cs
+++ b/AnkiSentenceCardBuilder/DataAccessLayer/Contexts/Anki2Context.cs
@@ -40,12 +40,6 @@ namespace AnkiJapaneseFlashcardManager.DataAccessLayer.Contexts
 				.Options;
 		}
 
-        public override void Dispose()
-        {
-			SqliteConnection.ClearPool((SqliteConnection) Database.GetDbConnection());
-			base.Dispose();
-		}
-
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             //Setup relationship between Deck and Note (one-to-many)

--- a/AnkiSentenceCardBuilder/DataAccessLayer/Helpers/DbContextHelper.cs
+++ b/AnkiSentenceCardBuilder/DataAccessLayer/Helpers/DbContextHelper.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnkiJapaneseFlashcardManager.DataAccessLayer.Helpers
+{
+	public static class DbContextHelper
+	{
+		public static void ClearSqlitePool(DbContext dbContext)
+		{
+			SqliteConnection.ClearPool((SqliteConnection) dbContext.Database.GetDbConnection());
+		}
+	}
+}

--- a/AnkiSentenceCardBuilder/Services/UpdateAnki2.cs
+++ b/AnkiSentenceCardBuilder/Services/UpdateAnki2.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using AnkiJapaneseFlashcardManager.DataAccessLayer.Contexts;
+using AnkiJapaneseFlashcardManager.DataAccessLayer.Helpers;
 using AnkiJapaneseFlashcardManager.DomainLayer.Entities;
 using AnkiSentenceCardBuilder.Controllers;
 using Azure.Storage.Blobs.Specialized;
@@ -32,7 +33,7 @@ namespace AnkiSentenceCardBuilder.Services
             var decks = anki2Controller.GetTable<Deck>();
 
 			//Cleanup
-			dbContext.Dispose();
+			DbContextHelper.ClearSqlitePool(dbContext);
 
 
 			//using var blobStreamReader = new StreamReader(stream);


### PR DESCRIPTION
Moved `Anki2Context.Dispose()`'s clear pool logic into `DbContextHelper.ClearSqlitePool()` and then removed `Anki2Context.Dispose()`.

Only need to call clear pool when immediately deleting the SQLite file after use. Keeping the logic in `Dispose()` would get rid of the EF's efficiency of reconnecting to the same SQLite file.